### PR TITLE
Specify baseURL for RSS readers

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,5 @@
 languageCode = "en-us"
+baseUrl = "https://blog.skouf.com/"
 title = "blog.skouf.com"
 theme = "skouf"
 publishDir = "docs"

--- a/docs/404.html
+++ b/docs/404.html
@@ -12,9 +12,9 @@
   <meta name="keywords" content="">
   <meta property="og:site_name" content="blog.skouf.com">
   <meta property="og:title" content="404 Page not found">
-  <meta property="og:url" content="/404.html">
+  <meta property="og:url" content="https://blog.skouf.com/404.html">
   
-  <meta property="og:image" content="image/theme/og.png">
+  <meta property="og:image" content="https://blog.skouf.com/image/theme/og.png">
   
   
   <meta property="og:description" content="">
@@ -23,12 +23,12 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:creator" content="@niksko">
   <meta name="twitter:title" content="404 Page not found">
-  <meta name="twitter:url" content="/404.html">
+  <meta name="twitter:url" content="https://blog.skouf.com/404.html">
   
   <meta name="twitter:description" content="">
   
   
-  <meta name="twitter:image:src" content="image/theme/og.png">
+  <meta name="twitter:image:src" content="https://blog.skouf.com/image/theme/og.png">
   
   <link rel="shortcut icon" href="/image/theme/favicon.ico">
   <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
@@ -36,7 +36,7 @@
   <link rel="stylesheet" href="https://unpkg.com/purecss@1.0.0/build/grids-responsive-min.css">
   <link rel="stylesheet" href="/css/style.css">
   <link rel="stylesheet" href="/css/syntax.css">
-  <link rel="alternate" href="index.xml" type="application/rss+xml" title="blog.skouf.com">
+  <link rel="alternate" href="https://blog.skouf.com/index.xml" type="application/rss+xml" title="blog.skouf.com">
 </head>
 
 <body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,9 +12,9 @@
   <meta name="keywords" content="">
   <meta property="og:site_name" content="blog.skouf.com">
   <meta property="og:title" content="blog.skouf.com">
-  <meta property="og:url" content="/">
+  <meta property="og:url" content="https://blog.skouf.com/">
   
-  <meta property="og:image" content="image/theme/og.png">
+  <meta property="og:image" content="https://blog.skouf.com/image/theme/og.png">
   
   
   <meta property="og:description" content="The personal blog of Nik Skoufis">
@@ -23,12 +23,12 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:creator" content="@niksko">
   <meta name="twitter:title" content="blog.skouf.com">
-  <meta name="twitter:url" content="/">
+  <meta name="twitter:url" content="https://blog.skouf.com/">
   
   <meta name="twitter:description" content="The personal blog of Nik Skoufis">
   
   
-  <meta name="twitter:image:src" content="image/theme/og.png">
+  <meta name="twitter:image:src" content="https://blog.skouf.com/image/theme/og.png">
   
   <link rel="shortcut icon" href="/image/theme/favicon.ico">
   <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
@@ -36,14 +36,14 @@
   <link rel="stylesheet" href="https://unpkg.com/purecss@1.0.0/build/grids-responsive-min.css">
   <link rel="stylesheet" href="/css/style.css">
   <link rel="stylesheet" href="/css/syntax.css">
-  <link rel="alternate" href="index.xml" type="application/rss+xml" title="blog.skouf.com">
+  <link rel="alternate" href="https://blog.skouf.com/index.xml" type="application/rss+xml" title="blog.skouf.com">
 </head>
 
 <body>
   <div id="wrap" class="wrap">
     <header class="header">
   
-  <h1><a href="">blog.skouf.com</a></h1>
+  <h1><a href="https://blog.skouf.com/">blog.skouf.com</a></h1>
   <p class="site-desc">The personal blog of Nik Skoufis</p>
   
 </header>
@@ -54,10 +54,10 @@
         <div class="pure-g">
           
             <article class="card pure-u-1 pure-u-md-1-2 pure-u-lg-1-3">
-  <a class="card__thumb" href="/posts/experiments-in-mushroom-garrum/">
+  <a class="card__thumb" href="https://blog.skouf.com/posts/experiments-in-mushroom-garrum/">
     <img src="/posts/experiments-in-mushroom-garrum/weighing_hu0ccfd9086dca6254ea7c5e79f088b1e3_4671749_600x300_fit_q75_box.jpg" alt="">
   </a>
-  <a href="/posts/experiments-in-mushroom-garrum/">
+  <a href="https://blog.skouf.com/posts/experiments-in-mushroom-garrum/">
     <h3>Experiments in mushroom garrum</h3>
   </a>
   <span>
@@ -68,10 +68,10 @@
 
           
             <article class="card pure-u-1 pure-u-md-1-2 pure-u-lg-1-3">
-  <a class="card__thumb" href="/posts/lacto-pepper-juice/">
+  <a class="card__thumb" href="https://blog.skouf.com/posts/lacto-pepper-juice/">
     <img src="/posts/lacto-pepper-juice/charred-peppers_hu0ccfd9086dca6254ea7c5e79f088b1e3_5075402_600x300_fit_q75_box.jpg" alt="">
   </a>
-  <a href="/posts/lacto-pepper-juice/">
+  <a href="https://blog.skouf.com/posts/lacto-pepper-juice/">
     <h3>Lacto-fermented red pepper juice</h3>
   </a>
   <span>
@@ -82,10 +82,10 @@
 
           
             <article class="card pure-u-1 pure-u-md-1-2 pure-u-lg-1-3">
-  <a class="card__thumb" href="/posts/fig-leaf-syrup/">
+  <a class="card__thumb" href="https://blog.skouf.com/posts/fig-leaf-syrup/">
     <img src="/posts/fig-leaf-syrup/lemonade_hu2753929d5d175bb2c34eff119cf2778e_7372554_600x300_fit_q75_box.jpg" alt="">
   </a>
-  <a href="/posts/fig-leaf-syrup/">
+  <a href="https://blog.skouf.com/posts/fig-leaf-syrup/">
     <h3>Fig leaf syrup and fig leaf lemonade</h3>
   </a>
   <span>
@@ -96,10 +96,10 @@
 
           
             <article class="card pure-u-1 pure-u-md-1-2 pure-u-lg-1-3">
-  <a class="card__thumb" href="/posts/iac-in-the-home-two-years-on/">
+  <a class="card__thumb" href="https://blog.skouf.com/posts/iac-in-the-home-two-years-on/">
     <img src="/posts/iac-in-the-home-two-years-on/container-ship_hu097f54c173504d3971b88bf561e54bf6_2086208_600x300_fit_q75_box.jpg" alt="">
   </a>
-  <a href="/posts/iac-in-the-home-two-years-on/">
+  <a href="https://blog.skouf.com/posts/iac-in-the-home-two-years-on/">
     <h3>IaC in the home - two years on</h3>
   </a>
   <span>
@@ -110,10 +110,10 @@
 
           
             <article class="card pure-u-1 pure-u-md-1-2 pure-u-lg-1-3">
-  <a class="card__thumb" href="/posts/blog-migration/blog-migration/">
+  <a class="card__thumb" href="https://blog.skouf.com/posts/blog-migration/blog-migration/">
     <img src="/image/theme/placeholder.png" alt="">
   </a>
-  <a href="/posts/blog-migration/blog-migration/">
+  <a href="https://blog.skouf.com/posts/blog-migration/blog-migration/">
     <h3>Blog migration</h3>
   </a>
   <span>
@@ -124,10 +124,10 @@
 
           
             <article class="card pure-u-1 pure-u-md-1-2 pure-u-lg-1-3">
-  <a class="card__thumb" href="/posts/istio-tls-policies/">
+  <a class="card__thumb" href="https://blog.skouf.com/posts/istio-tls-policies/">
     <img src="/posts/istio-tls-policies/sailboat_hue018e621fa59b0ab0c453270f3108f09_909769_600x300_fit_q75_box.jpg" alt="">
   </a>
-  <a href="/posts/istio-tls-policies/">
+  <a href="https://blog.skouf.com/posts/istio-tls-policies/">
     <h3>Istio TLS policies - ugly bits and undocumented bits</h3>
   </a>
   <span>
@@ -138,10 +138,10 @@
 
           
             <article class="card pure-u-1 pure-u-md-1-2 pure-u-lg-1-3">
-  <a class="card__thumb" href="/posts/iac-in-the-home-one-year-on/">
+  <a class="card__thumb" href="https://blog.skouf.com/posts/iac-in-the-home-one-year-on/">
     <img src="/posts/iac-in-the-home-one-year-on/servers_hub7a1f3d404ab6696b140ae38456c2986_1575286_600x300_fit_q75_box.jpg" alt="">
   </a>
-  <a href="/posts/iac-in-the-home-one-year-on/">
+  <a href="https://blog.skouf.com/posts/iac-in-the-home-one-year-on/">
     <h3>Infrastructure as code in the home - one year on</h3>
   </a>
   <span>
@@ -152,10 +152,10 @@
 
           
             <article class="card pure-u-1 pure-u-md-1-2 pure-u-lg-1-3">
-  <a class="card__thumb" href="/posts/iac-in-the-home/">
+  <a class="card__thumb" href="https://blog.skouf.com/posts/iac-in-the-home/">
     <img src="/posts/iac-in-the-home/overview_hu047fe7d13439038f3bc411c98994006f_70538_600x300_fit_box_2.png" alt="">
   </a>
-  <a href="/posts/iac-in-the-home/">
+  <a href="https://blog.skouf.com/posts/iac-in-the-home/">
     <h3>Infrastructure as code in the home</h3>
   </a>
   <span>
@@ -167,10 +167,10 @@ But when we don’t have hundreds of machines to manage, is IaC still useful?</p
 
           
             <article class="card pure-u-1 pure-u-md-1-2 pure-u-lg-1-3">
-  <a class="card__thumb" href="/posts/log-4-net-rolling-file-appender/">
+  <a class="card__thumb" href="https://blog.skouf.com/posts/log-4-net-rolling-file-appender/">
     <img src="/posts/log-4-net-rolling-file-appender/log4net-logo_hue59c5c936d6629363fcad316f789b221_41915_600x300_fit_q75_box.jpg" alt="">
   </a>
-  <a href="/posts/log-4-net-rolling-file-appender/">
+  <a href="https://blog.skouf.com/posts/log-4-net-rolling-file-appender/">
     <h3>Log4net rolling file appender with multiple projects</h3>
   </a>
   <span>
@@ -182,10 +182,10 @@ If I can save another poor soul some time, then it will be well worth writing th
 
           
             <article class="card pure-u-1 pure-u-md-1-2 pure-u-lg-1-3">
-  <a class="card__thumb" href="/posts/monterey-k104-restoration/">
+  <a class="card__thumb" href="https://blog.skouf.com/posts/monterey-k104-restoration/">
     <img src="/posts/monterey-k104-restoration/first-image_hu75ec642e3e4042f80f9b732879d4760b_171886_600x300_fit_q75_box.jpg" alt="">
   </a>
-  <a href="/posts/monterey-k104-restoration/">
+  <a href="https://blog.skouf.com/posts/monterey-k104-restoration/">
     <h3>Monterey K104 restoration</h3>
   </a>
   <span>

--- a/docs/index.xml
+++ b/docs/index.xml
@@ -2,100 +2,100 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>blog.skouf.com</title>
-    <link>/</link>
+    <link>https://blog.skouf.com/</link>
     <description>Recent content on blog.skouf.com</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Sat, 27 Feb 2021 12:00:14 +0000</lastBuildDate><atom:link href="/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Sat, 27 Feb 2021 12:00:14 +0000</lastBuildDate><atom:link href="https://blog.skouf.com/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Experiments in mushroom garrum</title>
-      <link>/posts/experiments-in-mushroom-garrum/</link>
+      <link>https://blog.skouf.com/posts/experiments-in-mushroom-garrum/</link>
       <pubDate>Sat, 27 Feb 2021 12:00:14 +0000</pubDate>
       
-      <guid>/posts/experiments-in-mushroom-garrum/</guid>
+      <guid>https://blog.skouf.com/posts/experiments-in-mushroom-garrum/</guid>
       <description>Recently I&amp;rsquo;ve been experimenting with a new technique for making incredibly fast garrums. This article documents some of my findings when experimenting with making garrum from mushrooms.</description>
     </item>
     
     <item>
       <title>Lacto-fermented red pepper juice</title>
-      <link>/posts/lacto-pepper-juice/</link>
+      <link>https://blog.skouf.com/posts/lacto-pepper-juice/</link>
       <pubDate>Wed, 24 Feb 2021 22:30:51 +0000</pubDate>
       
-      <guid>/posts/lacto-pepper-juice/</guid>
+      <guid>https://blog.skouf.com/posts/lacto-pepper-juice/</guid>
       <description>How to make a tangy, delicious, smoky, umami rich ferment from red peppers</description>
     </item>
     
     <item>
       <title>Fig leaf syrup and fig leaf lemonade</title>
-      <link>/posts/fig-leaf-syrup/</link>
+      <link>https://blog.skouf.com/posts/fig-leaf-syrup/</link>
       <pubDate>Sun, 14 Feb 2021 01:00:56 +0000</pubDate>
       
-      <guid>/posts/fig-leaf-syrup/</guid>
+      <guid>https://blog.skouf.com/posts/fig-leaf-syrup/</guid>
       <description>A unique and versatile syrup, and a refreshing, summery lemonade</description>
     </item>
     
     <item>
       <title>IaC in the home - two years on</title>
-      <link>/posts/iac-in-the-home-two-years-on/</link>
+      <link>https://blog.skouf.com/posts/iac-in-the-home-two-years-on/</link>
       <pubDate>Sat, 11 Apr 2020 02:25:23 +0000</pubDate>
       
-      <guid>/posts/iac-in-the-home-two-years-on/</guid>
+      <guid>https://blog.skouf.com/posts/iac-in-the-home-two-years-on/</guid>
       <description>After two years of running a home Kubernetes setup, I have more thoughts and lessons about how to run a home cluster.</description>
     </item>
     
     <item>
       <title>Blog migration</title>
-      <link>/posts/blog-migration/blog-migration/</link>
+      <link>https://blog.skouf.com/posts/blog-migration/blog-migration/</link>
       <pubDate>Wed, 08 Apr 2020 02:30:18 +0000</pubDate>
       
-      <guid>/posts/blog-migration/blog-migration/</guid>
+      <guid>https://blog.skouf.com/posts/blog-migration/blog-migration/</guid>
       <description>It&amp;rsquo;s finally time to take my blog off of Medium and host it myself.</description>
     </item>
     
     <item>
       <title>Istio TLS policies - ugly bits and undocumented bits</title>
-      <link>/posts/istio-tls-policies/</link>
+      <link>https://blog.skouf.com/posts/istio-tls-policies/</link>
       <pubDate>Wed, 12 Jun 2019 00:43:25 +0000</pubDate>
       
-      <guid>/posts/istio-tls-policies/</guid>
+      <guid>https://blog.skouf.com/posts/istio-tls-policies/</guid>
       <description>One of the selling points of deploying Istio in your Kubernetes cluster is that it provides mechanisms to enforce authentication between pods communicating with other services within the cluster. The documentation of these leaves a lot to be desired, as we discovered when we first started playing with these features while gearing up to roll out Istio more widely.</description>
     </item>
     
     <item>
       <title>Infrastructure as code in the home - one year on</title>
-      <link>/posts/iac-in-the-home-one-year-on/</link>
+      <link>https://blog.skouf.com/posts/iac-in-the-home-one-year-on/</link>
       <pubDate>Wed, 09 Jan 2019 00:43:25 +0000</pubDate>
       
-      <guid>/posts/iac-in-the-home-one-year-on/</guid>
+      <guid>https://blog.skouf.com/posts/iac-in-the-home-one-year-on/</guid>
       <description>One year on, I revisit my home infrastructure as code setup. I explore what worked, what didn&amp;rsquo;t and what has changed over the last year.</description>
     </item>
     
     <item>
       <title>Infrastructure as code in the home</title>
-      <link>/posts/iac-in-the-home/</link>
+      <link>https://blog.skouf.com/posts/iac-in-the-home/</link>
       <pubDate>Wed, 25 Apr 2018 23:12:23 +1100</pubDate>
       
-      <guid>/posts/iac-in-the-home/</guid>
+      <guid>https://blog.skouf.com/posts/iac-in-the-home/</guid>
       <description>&lt;p&gt;Infrastructure as Code (herein IaC) is ubiquitous when managing large infrastructure deployments.
 But when we don’t have hundreds of machines to manage, is IaC still useful?&lt;/p&gt;</description>
     </item>
     
     <item>
       <title>Log4net rolling file appender with multiple projects</title>
-      <link>/posts/log-4-net-rolling-file-appender/</link>
+      <link>https://blog.skouf.com/posts/log-4-net-rolling-file-appender/</link>
       <pubDate>Mon, 03 Apr 2017 23:12:23 +1100</pubDate>
       
-      <guid>/posts/log-4-net-rolling-file-appender/</guid>
+      <guid>https://blog.skouf.com/posts/log-4-net-rolling-file-appender/</guid>
       <description>&lt;p&gt;The purpose of this article is to document a minor frustration I ran into at work a few weeks ago, in the hopes that somebody else with the same issue will stumble across it.
 If I can save another poor soul some time, then it will be well worth writing this.&lt;/p&gt;</description>
     </item>
     
     <item>
       <title>Monterey K104 restoration</title>
-      <link>/posts/monterey-k104-restoration/</link>
+      <link>https://blog.skouf.com/posts/monterey-k104-restoration/</link>
       <pubDate>Sat, 10 Sep 2016 23:12:23 +1100</pubDate>
       
-      <guid>/posts/monterey-k104-restoration/</guid>
+      <guid>https://blog.skouf.com/posts/monterey-k104-restoration/</guid>
       <description>A detailed step-by-step of restoring a keyboard older than I am. Not for the faint-of-keyboard.</description>
     </item>
     

--- a/docs/page/1/index.html
+++ b/docs/page/1/index.html
@@ -1,1 +1,1 @@
-<!DOCTYPE html><html><head><title>/</title><link rel="canonical" href="/"/><meta name="robots" content="noindex"><meta charset="utf-8" /><meta http-equiv="refresh" content="0; url=/" /></head></html>
+<!DOCTYPE html><html><head><title>https://blog.skouf.com/</title><link rel="canonical" href="https://blog.skouf.com/"/><meta name="robots" content="noindex"><meta charset="utf-8" /><meta http-equiv="refresh" content="0; url=https://blog.skouf.com/" /></head></html>

--- a/docs/posts/blog-migration/blog-migration/index.html
+++ b/docs/posts/blog-migration/blog-migration/index.html
@@ -12,9 +12,9 @@
   <meta name="keywords" content="">
   <meta property="og:site_name" content="blog.skouf.com">
   <meta property="og:title" content="Blog migration">
-  <meta property="og:url" content="/posts/blog-migration/blog-migration/">
+  <meta property="og:url" content="https://blog.skouf.com/posts/blog-migration/blog-migration/">
   
-  <meta property="og:image" content="image/theme/og.png">
+  <meta property="og:image" content="https://blog.skouf.com/image/theme/og.png">
   
   
   <meta property="og:description" content="It&rsquo;s finally time to take my blog off of Medium and host it myself.">
@@ -23,12 +23,12 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:creator" content="@niksko">
   <meta name="twitter:title" content="Blog migration">
-  <meta name="twitter:url" content="/posts/blog-migration/blog-migration/">
+  <meta name="twitter:url" content="https://blog.skouf.com/posts/blog-migration/blog-migration/">
   
   <meta name="twitter:description" content="It&rsquo;s finally time to take my blog off of Medium and host it myself.">
   
   
-  <meta name="twitter:image:src" content="image/theme/og.png">
+  <meta name="twitter:image:src" content="https://blog.skouf.com/image/theme/og.png">
   
   <link rel="shortcut icon" href="/image/theme/favicon.ico">
   <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
@@ -36,7 +36,7 @@
   <link rel="stylesheet" href="https://unpkg.com/purecss@1.0.0/build/grids-responsive-min.css">
   <link rel="stylesheet" href="/css/style.css">
   <link rel="stylesheet" href="/css/syntax.css">
-  <link rel="alternate" href="index.xml" type="application/rss+xml" title="blog.skouf.com">
+  <link rel="alternate" href="https://blog.skouf.com/index.xml" type="application/rss+xml" title="blog.skouf.com">
 </head>
 
 <body>
@@ -151,7 +151,7 @@ If you notice any glaring issues, let me know via the social media links below.<
   <ol class="pure-g">
     
       <li class="pure-u-1 pure-u-md-1-2 post-nav-prev">
-        <a href="/posts/iac-in-the-home-two-years-on/">
+        <a href="https://blog.skouf.com/posts/iac-in-the-home-two-years-on/">
               <span class="post-nav-label">Next<span>
               <span class="post-nav-title">
                 IaC in the home - two years on
@@ -161,7 +161,7 @@ If you notice any glaring issues, let me know via the social media links below.<
     
     
       <li class="pure-u-1 pure-u-md-1-2 post-nav-next">
-        <a href="/posts/istio-tls-policies/">
+        <a href="https://blog.skouf.com/posts/istio-tls-policies/">
           <span class="post-nav-label">Previous</span>
           <span class="post-nav-title">
                 Istio TLS policies - ugly bits and undocumented bits

--- a/docs/posts/experiments-in-mushroom-garrum/index.html
+++ b/docs/posts/experiments-in-mushroom-garrum/index.html
@@ -12,9 +12,9 @@
   <meta name="keywords" content="">
   <meta property="og:site_name" content="blog.skouf.com">
   <meta property="og:title" content="Experiments in mushroom garrum">
-  <meta property="og:url" content="/posts/experiments-in-mushroom-garrum/">
+  <meta property="og:url" content="https://blog.skouf.com/posts/experiments-in-mushroom-garrum/">
   
-  <meta property="og:image" content="weighing.jpg">
+  <meta property="og:image" content="https://blog.skouf.com/weighing.jpg">
   
   
   <meta property="og:description" content="Recently I&rsquo;ve been experimenting with a new technique for making incredibly fast garrums. This article documents some of my findings when experimenting with making garrum from mushrooms.">
@@ -23,12 +23,12 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:creator" content="@niksko">
   <meta name="twitter:title" content="Experiments in mushroom garrum">
-  <meta name="twitter:url" content="/posts/experiments-in-mushroom-garrum/">
+  <meta name="twitter:url" content="https://blog.skouf.com/posts/experiments-in-mushroom-garrum/">
   
   <meta name="twitter:description" content="Recently I&rsquo;ve been experimenting with a new technique for making incredibly fast garrums. This article documents some of my findings when experimenting with making garrum from mushrooms.">
   
   
-  <meta name="twitter:image:src" content="weighing.jpg">
+  <meta name="twitter:image:src" content="https://blog.skouf.com/weighing.jpg">
   
   <link rel="shortcut icon" href="/image/theme/favicon.ico">
   <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
@@ -36,7 +36,7 @@
   <link rel="stylesheet" href="https://unpkg.com/purecss@1.0.0/build/grids-responsive-min.css">
   <link rel="stylesheet" href="/css/style.css">
   <link rel="stylesheet" href="/css/syntax.css">
-  <link rel="alternate" href="index.xml" type="application/rss+xml" title="blog.skouf.com">
+  <link rel="alternate" href="https://blog.skouf.com/index.xml" type="application/rss+xml" title="blog.skouf.com">
 </head>
 
 <body>
@@ -551,7 +551,7 @@ that give these nutritionally void compounds tasty flavors.</p>
     
     
       <li class="pure-u-1 pure-u-md-1-2 post-nav-next">
-        <a href="/posts/lacto-pepper-juice/">
+        <a href="https://blog.skouf.com/posts/lacto-pepper-juice/">
           <span class="post-nav-label">Previous</span>
           <span class="post-nav-title">
                 Lacto-fermented red pepper juice

--- a/docs/posts/fig-leaf-syrup/index.html
+++ b/docs/posts/fig-leaf-syrup/index.html
@@ -12,9 +12,9 @@
   <meta name="keywords" content="">
   <meta property="og:site_name" content="blog.skouf.com">
   <meta property="og:title" content="Fig leaf syrup and fig leaf lemonade">
-  <meta property="og:url" content="/posts/fig-leaf-syrup/">
+  <meta property="og:url" content="https://blog.skouf.com/posts/fig-leaf-syrup/">
   
-  <meta property="og:image" content="lemonade.jpg">
+  <meta property="og:image" content="https://blog.skouf.com/lemonade.jpg">
   
   
   <meta property="og:description" content="A unique and versatile syrup, and a refreshing, summery lemonade">
@@ -23,12 +23,12 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:creator" content="@niksko">
   <meta name="twitter:title" content="Fig leaf syrup and fig leaf lemonade">
-  <meta name="twitter:url" content="/posts/fig-leaf-syrup/">
+  <meta name="twitter:url" content="https://blog.skouf.com/posts/fig-leaf-syrup/">
   
   <meta name="twitter:description" content="A unique and versatile syrup, and a refreshing, summery lemonade">
   
   
-  <meta name="twitter:image:src" content="lemonade.jpg">
+  <meta name="twitter:image:src" content="https://blog.skouf.com/lemonade.jpg">
   
   <link rel="shortcut icon" href="/image/theme/favicon.ico">
   <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
@@ -36,7 +36,7 @@
   <link rel="stylesheet" href="https://unpkg.com/purecss@1.0.0/build/grids-responsive-min.css">
   <link rel="stylesheet" href="/css/style.css">
   <link rel="stylesheet" href="/css/syntax.css">
-  <link rel="alternate" href="index.xml" type="application/rss+xml" title="blog.skouf.com">
+  <link rel="alternate" href="https://blog.skouf.com/index.xml" type="application/rss+xml" title="blog.skouf.com">
 </head>
 
 <body>
@@ -377,7 +377,7 @@ A spring of mint and a wedge of lemon make a great garnish.</p>
   <ol class="pure-g">
     
       <li class="pure-u-1 pure-u-md-1-2 post-nav-prev">
-        <a href="/posts/lacto-pepper-juice/">
+        <a href="https://blog.skouf.com/posts/lacto-pepper-juice/">
               <span class="post-nav-label">Next<span>
               <span class="post-nav-title">
                 Lacto-fermented red pepper juice
@@ -387,7 +387,7 @@ A spring of mint and a wedge of lemon make a great garnish.</p>
     
     
       <li class="pure-u-1 pure-u-md-1-2 post-nav-next">
-        <a href="/posts/iac-in-the-home-two-years-on/">
+        <a href="https://blog.skouf.com/posts/iac-in-the-home-two-years-on/">
           <span class="post-nav-label">Previous</span>
           <span class="post-nav-title">
                 IaC in the home - two years on

--- a/docs/posts/iac-in-the-home-one-year-on/index.html
+++ b/docs/posts/iac-in-the-home-one-year-on/index.html
@@ -12,9 +12,9 @@
   <meta name="keywords" content="">
   <meta property="og:site_name" content="blog.skouf.com">
   <meta property="og:title" content="Infrastructure as code in the home - one year on">
-  <meta property="og:url" content="/posts/iac-in-the-home-one-year-on/">
+  <meta property="og:url" content="https://blog.skouf.com/posts/iac-in-the-home-one-year-on/">
   
-  <meta property="og:image" content="servers.jpg">
+  <meta property="og:image" content="https://blog.skouf.com/servers.jpg">
   
   
   <meta property="og:description" content="One year on, I revisit my home infrastructure as code setup. I explore what worked, what didn&rsquo;t and what has changed over the last year.">
@@ -23,12 +23,12 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:creator" content="@niksko">
   <meta name="twitter:title" content="Infrastructure as code in the home - one year on">
-  <meta name="twitter:url" content="/posts/iac-in-the-home-one-year-on/">
+  <meta name="twitter:url" content="https://blog.skouf.com/posts/iac-in-the-home-one-year-on/">
   
   <meta name="twitter:description" content="One year on, I revisit my home infrastructure as code setup. I explore what worked, what didn&rsquo;t and what has changed over the last year.">
   
   
-  <meta name="twitter:image:src" content="servers.jpg">
+  <meta name="twitter:image:src" content="https://blog.skouf.com/servers.jpg">
   
   <link rel="shortcut icon" href="/image/theme/favicon.ico">
   <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
@@ -36,7 +36,7 @@
   <link rel="stylesheet" href="https://unpkg.com/purecss@1.0.0/build/grids-responsive-min.css">
   <link rel="stylesheet" href="/css/style.css">
   <link rel="stylesheet" href="/css/syntax.css">
-  <link rel="alternate" href="index.xml" type="application/rss+xml" title="blog.skouf.com">
+  <link rel="alternate" href="https://blog.skouf.com/index.xml" type="application/rss+xml" title="blog.skouf.com">
 </head>
 
 <body>
@@ -57,7 +57,7 @@
 
       <div class="post-content">
         <p><em>It&rsquo;s been almost a year since I published my original article on running my Kubernetes setup at home.
-Have a read of <a href="/posts/iac-in-the-home/">the original</a> for context.</em></p>
+Have a read of <a href="https://blog.skouf.com/posts/iac-in-the-home/">the original</a> for context.</em></p>
 
 
 
@@ -202,7 +202,7 @@ Hopefully I&rsquo;ll have another update in a year or so.</p>
   <ol class="pure-g">
     
       <li class="pure-u-1 pure-u-md-1-2 post-nav-prev">
-        <a href="/posts/istio-tls-policies/">
+        <a href="https://blog.skouf.com/posts/istio-tls-policies/">
               <span class="post-nav-label">Next<span>
               <span class="post-nav-title">
                 Istio TLS policies - ugly bits and undocumented bits
@@ -212,7 +212,7 @@ Hopefully I&rsquo;ll have another update in a year or so.</p>
     
     
       <li class="pure-u-1 pure-u-md-1-2 post-nav-next">
-        <a href="/posts/iac-in-the-home/">
+        <a href="https://blog.skouf.com/posts/iac-in-the-home/">
           <span class="post-nav-label">Previous</span>
           <span class="post-nav-title">
                 Infrastructure as code in the home

--- a/docs/posts/iac-in-the-home-two-years-on/index.html
+++ b/docs/posts/iac-in-the-home-two-years-on/index.html
@@ -12,9 +12,9 @@
   <meta name="keywords" content="">
   <meta property="og:site_name" content="blog.skouf.com">
   <meta property="og:title" content="IaC in the home - two years on">
-  <meta property="og:url" content="/posts/iac-in-the-home-two-years-on/">
+  <meta property="og:url" content="https://blog.skouf.com/posts/iac-in-the-home-two-years-on/">
   
-  <meta property="og:image" content="container-ship.jpg">
+  <meta property="og:image" content="https://blog.skouf.com/container-ship.jpg">
   
   
   <meta property="og:description" content="After two years of running a home Kubernetes setup, I have more thoughts and lessons about how to run a home cluster.">
@@ -23,12 +23,12 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:creator" content="@niksko">
   <meta name="twitter:title" content="IaC in the home - two years on">
-  <meta name="twitter:url" content="/posts/iac-in-the-home-two-years-on/">
+  <meta name="twitter:url" content="https://blog.skouf.com/posts/iac-in-the-home-two-years-on/">
   
   <meta name="twitter:description" content="After two years of running a home Kubernetes setup, I have more thoughts and lessons about how to run a home cluster.">
   
   
-  <meta name="twitter:image:src" content="container-ship.jpg">
+  <meta name="twitter:image:src" content="https://blog.skouf.com/container-ship.jpg">
   
   <link rel="shortcut icon" href="/image/theme/favicon.ico">
   <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
@@ -36,7 +36,7 @@
   <link rel="stylesheet" href="https://unpkg.com/purecss@1.0.0/build/grids-responsive-min.css">
   <link rel="stylesheet" href="/css/style.css">
   <link rel="stylesheet" href="/css/syntax.css">
-  <link rel="alternate" href="index.xml" type="application/rss+xml" title="blog.skouf.com">
+  <link rel="alternate" href="https://blog.skouf.com/index.xml" type="application/rss+xml" title="blog.skouf.com">
 </head>
 
 <body>
@@ -57,7 +57,7 @@
 
       <div class="post-content">
         <p><em>This is the third post in a series about how I manage my home Kubernetes cluster.
-For context, read <a href="/posts/iac-in-the-home/">the original post</a> and <a href="/posts/iac-in-the-home-one-year-on/">the followup at one year</a>.</em></p>
+For context, read <a href="https://blog.skouf.com/posts/iac-in-the-home/">the original post</a> and <a href="https://blog.skouf.com/posts/iac-in-the-home-one-year-on/">the followup at one year</a>.</em></p>
 
 
 
@@ -422,7 +422,7 @@ Considering that I&rsquo;m learning a lot along the way, I&rsquo;m really happy 
   <ol class="pure-g">
     
       <li class="pure-u-1 pure-u-md-1-2 post-nav-prev">
-        <a href="/posts/fig-leaf-syrup/">
+        <a href="https://blog.skouf.com/posts/fig-leaf-syrup/">
               <span class="post-nav-label">Next<span>
               <span class="post-nav-title">
                 Fig leaf syrup and fig leaf lemonade
@@ -432,7 +432,7 @@ Considering that I&rsquo;m learning a lot along the way, I&rsquo;m really happy 
     
     
       <li class="pure-u-1 pure-u-md-1-2 post-nav-next">
-        <a href="/posts/blog-migration/blog-migration/">
+        <a href="https://blog.skouf.com/posts/blog-migration/blog-migration/">
           <span class="post-nav-label">Previous</span>
           <span class="post-nav-title">
                 Blog migration

--- a/docs/posts/iac-in-the-home/index.html
+++ b/docs/posts/iac-in-the-home/index.html
@@ -13,9 +13,9 @@ But when we don’t have hundreds of machines to manage, is IaC still useful?">
   <meta name="keywords" content="">
   <meta property="og:site_name" content="blog.skouf.com">
   <meta property="og:title" content="Infrastructure as code in the home">
-  <meta property="og:url" content="/posts/iac-in-the-home/">
+  <meta property="og:url" content="https://blog.skouf.com/posts/iac-in-the-home/">
   
-  <meta property="og:image" content="overview.png">
+  <meta property="og:image" content="https://blog.skouf.com/overview.png">
   
   
   <meta property="og:description" content="Infrastructure as Code (herein IaC) is ubiquitous when managing large infrastructure deployments.
@@ -25,13 +25,13 @@ But when we don’t have hundreds of machines to manage, is IaC still useful?">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:creator" content="@niksko">
   <meta name="twitter:title" content="Infrastructure as code in the home">
-  <meta name="twitter:url" content="/posts/iac-in-the-home/">
+  <meta name="twitter:url" content="https://blog.skouf.com/posts/iac-in-the-home/">
   
   <meta name="twitter:description" content="Infrastructure as Code (herein IaC) is ubiquitous when managing large infrastructure deployments.
 But when we don’t have hundreds of machines to manage, is IaC still useful?">
   
   
-  <meta name="twitter:image:src" content="overview.png">
+  <meta name="twitter:image:src" content="https://blog.skouf.com/overview.png">
   
   <link rel="shortcut icon" href="/image/theme/favicon.ico">
   <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
@@ -39,7 +39,7 @@ But when we don’t have hundreds of machines to manage, is IaC still useful?">
   <link rel="stylesheet" href="https://unpkg.com/purecss@1.0.0/build/grids-responsive-min.css">
   <link rel="stylesheet" href="/css/style.css">
   <link rel="stylesheet" href="/css/syntax.css">
-  <link rel="alternate" href="index.xml" type="application/rss+xml" title="blog.skouf.com">
+  <link rel="alternate" href="https://blog.skouf.com/index.xml" type="application/rss+xml" title="blog.skouf.com">
 </head>
 
 <body>
@@ -162,7 +162,7 @@ Keep an eye out for the next post in this series, where I’ll be discussing man
   <ol class="pure-g">
     
       <li class="pure-u-1 pure-u-md-1-2 post-nav-prev">
-        <a href="/posts/iac-in-the-home-one-year-on/">
+        <a href="https://blog.skouf.com/posts/iac-in-the-home-one-year-on/">
               <span class="post-nav-label">Next<span>
               <span class="post-nav-title">
                 Infrastructure as code in the home - one year on
@@ -172,7 +172,7 @@ Keep an eye out for the next post in this series, where I’ll be discussing man
     
     
       <li class="pure-u-1 pure-u-md-1-2 post-nav-next">
-        <a href="/posts/log-4-net-rolling-file-appender/">
+        <a href="https://blog.skouf.com/posts/log-4-net-rolling-file-appender/">
           <span class="post-nav-label">Previous</span>
           <span class="post-nav-title">
                 Log4net rolling file appender with multiple projects

--- a/docs/posts/index.html
+++ b/docs/posts/index.html
@@ -12,9 +12,9 @@
   <meta name="keywords" content="">
   <meta property="og:site_name" content="blog.skouf.com">
   <meta property="og:title" content="Posts">
-  <meta property="og:url" content="/posts/">
+  <meta property="og:url" content="https://blog.skouf.com/posts/">
   
-  <meta property="og:image" content="image/theme/og.png">
+  <meta property="og:image" content="https://blog.skouf.com/image/theme/og.png">
   
   
   <meta property="og:description" content="">
@@ -23,12 +23,12 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:creator" content="@niksko">
   <meta name="twitter:title" content="Posts">
-  <meta name="twitter:url" content="/posts/">
+  <meta name="twitter:url" content="https://blog.skouf.com/posts/">
   
   <meta name="twitter:description" content="">
   
   
-  <meta name="twitter:image:src" content="image/theme/og.png">
+  <meta name="twitter:image:src" content="https://blog.skouf.com/image/theme/og.png">
   
   <link rel="shortcut icon" href="/image/theme/favicon.ico">
   <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
@@ -36,7 +36,7 @@
   <link rel="stylesheet" href="https://unpkg.com/purecss@1.0.0/build/grids-responsive-min.css">
   <link rel="stylesheet" href="/css/style.css">
   <link rel="stylesheet" href="/css/syntax.css">
-  <link rel="alternate" href="index.xml" type="application/rss+xml" title="blog.skouf.com">
+  <link rel="alternate" href="https://blog.skouf.com/index.xml" type="application/rss+xml" title="blog.skouf.com">
 </head>
 
 <body>
@@ -53,10 +53,10 @@
         <div class="pure-g">
           
             <article class="card pure-u-1 pure-u-md-1-2 pure-u-lg-1-3">
-  <a class="card__thumb" href="/posts/experiments-in-mushroom-garrum/">
+  <a class="card__thumb" href="https://blog.skouf.com/posts/experiments-in-mushroom-garrum/">
     <img src="/posts/experiments-in-mushroom-garrum/weighing_hu0ccfd9086dca6254ea7c5e79f088b1e3_4671749_600x300_fit_q75_box.jpg" alt="">
   </a>
-  <a href="/posts/experiments-in-mushroom-garrum/">
+  <a href="https://blog.skouf.com/posts/experiments-in-mushroom-garrum/">
     <h3>Experiments in mushroom garrum</h3>
   </a>
   <span>
@@ -67,10 +67,10 @@
 
           
             <article class="card pure-u-1 pure-u-md-1-2 pure-u-lg-1-3">
-  <a class="card__thumb" href="/posts/lacto-pepper-juice/">
+  <a class="card__thumb" href="https://blog.skouf.com/posts/lacto-pepper-juice/">
     <img src="/posts/lacto-pepper-juice/charred-peppers_hu0ccfd9086dca6254ea7c5e79f088b1e3_5075402_600x300_fit_q75_box.jpg" alt="">
   </a>
-  <a href="/posts/lacto-pepper-juice/">
+  <a href="https://blog.skouf.com/posts/lacto-pepper-juice/">
     <h3>Lacto-fermented red pepper juice</h3>
   </a>
   <span>
@@ -81,10 +81,10 @@
 
           
             <article class="card pure-u-1 pure-u-md-1-2 pure-u-lg-1-3">
-  <a class="card__thumb" href="/posts/fig-leaf-syrup/">
+  <a class="card__thumb" href="https://blog.skouf.com/posts/fig-leaf-syrup/">
     <img src="/posts/fig-leaf-syrup/lemonade_hu2753929d5d175bb2c34eff119cf2778e_7372554_600x300_fit_q75_box.jpg" alt="">
   </a>
-  <a href="/posts/fig-leaf-syrup/">
+  <a href="https://blog.skouf.com/posts/fig-leaf-syrup/">
     <h3>Fig leaf syrup and fig leaf lemonade</h3>
   </a>
   <span>
@@ -95,10 +95,10 @@
 
           
             <article class="card pure-u-1 pure-u-md-1-2 pure-u-lg-1-3">
-  <a class="card__thumb" href="/posts/iac-in-the-home-two-years-on/">
+  <a class="card__thumb" href="https://blog.skouf.com/posts/iac-in-the-home-two-years-on/">
     <img src="/posts/iac-in-the-home-two-years-on/container-ship_hu097f54c173504d3971b88bf561e54bf6_2086208_600x300_fit_q75_box.jpg" alt="">
   </a>
-  <a href="/posts/iac-in-the-home-two-years-on/">
+  <a href="https://blog.skouf.com/posts/iac-in-the-home-two-years-on/">
     <h3>IaC in the home - two years on</h3>
   </a>
   <span>
@@ -109,10 +109,10 @@
 
           
             <article class="card pure-u-1 pure-u-md-1-2 pure-u-lg-1-3">
-  <a class="card__thumb" href="/posts/blog-migration/blog-migration/">
+  <a class="card__thumb" href="https://blog.skouf.com/posts/blog-migration/blog-migration/">
     <img src="/image/theme/placeholder.png" alt="">
   </a>
-  <a href="/posts/blog-migration/blog-migration/">
+  <a href="https://blog.skouf.com/posts/blog-migration/blog-migration/">
     <h3>Blog migration</h3>
   </a>
   <span>
@@ -123,10 +123,10 @@
 
           
             <article class="card pure-u-1 pure-u-md-1-2 pure-u-lg-1-3">
-  <a class="card__thumb" href="/posts/istio-tls-policies/">
+  <a class="card__thumb" href="https://blog.skouf.com/posts/istio-tls-policies/">
     <img src="/posts/istio-tls-policies/sailboat_hue018e621fa59b0ab0c453270f3108f09_909769_600x300_fit_q75_box.jpg" alt="">
   </a>
-  <a href="/posts/istio-tls-policies/">
+  <a href="https://blog.skouf.com/posts/istio-tls-policies/">
     <h3>Istio TLS policies - ugly bits and undocumented bits</h3>
   </a>
   <span>
@@ -137,10 +137,10 @@
 
           
             <article class="card pure-u-1 pure-u-md-1-2 pure-u-lg-1-3">
-  <a class="card__thumb" href="/posts/iac-in-the-home-one-year-on/">
+  <a class="card__thumb" href="https://blog.skouf.com/posts/iac-in-the-home-one-year-on/">
     <img src="/posts/iac-in-the-home-one-year-on/servers_hub7a1f3d404ab6696b140ae38456c2986_1575286_600x300_fit_q75_box.jpg" alt="">
   </a>
-  <a href="/posts/iac-in-the-home-one-year-on/">
+  <a href="https://blog.skouf.com/posts/iac-in-the-home-one-year-on/">
     <h3>Infrastructure as code in the home - one year on</h3>
   </a>
   <span>
@@ -151,10 +151,10 @@
 
           
             <article class="card pure-u-1 pure-u-md-1-2 pure-u-lg-1-3">
-  <a class="card__thumb" href="/posts/iac-in-the-home/">
+  <a class="card__thumb" href="https://blog.skouf.com/posts/iac-in-the-home/">
     <img src="/posts/iac-in-the-home/overview_hu047fe7d13439038f3bc411c98994006f_70538_600x300_fit_box_2.png" alt="">
   </a>
-  <a href="/posts/iac-in-the-home/">
+  <a href="https://blog.skouf.com/posts/iac-in-the-home/">
     <h3>Infrastructure as code in the home</h3>
   </a>
   <span>
@@ -166,10 +166,10 @@ But when we don’t have hundreds of machines to manage, is IaC still useful?</p
 
           
             <article class="card pure-u-1 pure-u-md-1-2 pure-u-lg-1-3">
-  <a class="card__thumb" href="/posts/log-4-net-rolling-file-appender/">
+  <a class="card__thumb" href="https://blog.skouf.com/posts/log-4-net-rolling-file-appender/">
     <img src="/posts/log-4-net-rolling-file-appender/log4net-logo_hue59c5c936d6629363fcad316f789b221_41915_600x300_fit_q75_box.jpg" alt="">
   </a>
-  <a href="/posts/log-4-net-rolling-file-appender/">
+  <a href="https://blog.skouf.com/posts/log-4-net-rolling-file-appender/">
     <h3>Log4net rolling file appender with multiple projects</h3>
   </a>
   <span>
@@ -181,10 +181,10 @@ If I can save another poor soul some time, then it will be well worth writing th
 
           
             <article class="card pure-u-1 pure-u-md-1-2 pure-u-lg-1-3">
-  <a class="card__thumb" href="/posts/monterey-k104-restoration/">
+  <a class="card__thumb" href="https://blog.skouf.com/posts/monterey-k104-restoration/">
     <img src="/posts/monterey-k104-restoration/first-image_hu75ec642e3e4042f80f9b732879d4760b_171886_600x300_fit_q75_box.jpg" alt="">
   </a>
-  <a href="/posts/monterey-k104-restoration/">
+  <a href="https://blog.skouf.com/posts/monterey-k104-restoration/">
     <h3>Monterey K104 restoration</h3>
   </a>
   <span>

--- a/docs/posts/index.xml
+++ b/docs/posts/index.xml
@@ -2,100 +2,100 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>Posts on blog.skouf.com</title>
-    <link>/posts/</link>
+    <link>https://blog.skouf.com/posts/</link>
     <description>Recent content in Posts on blog.skouf.com</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Sat, 27 Feb 2021 12:00:14 +0000</lastBuildDate><atom:link href="/posts/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Sat, 27 Feb 2021 12:00:14 +0000</lastBuildDate><atom:link href="https://blog.skouf.com/posts/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Experiments in mushroom garrum</title>
-      <link>/posts/experiments-in-mushroom-garrum/</link>
+      <link>https://blog.skouf.com/posts/experiments-in-mushroom-garrum/</link>
       <pubDate>Sat, 27 Feb 2021 12:00:14 +0000</pubDate>
       
-      <guid>/posts/experiments-in-mushroom-garrum/</guid>
+      <guid>https://blog.skouf.com/posts/experiments-in-mushroom-garrum/</guid>
       <description>Recently I&amp;rsquo;ve been experimenting with a new technique for making incredibly fast garrums. This article documents some of my findings when experimenting with making garrum from mushrooms.</description>
     </item>
     
     <item>
       <title>Lacto-fermented red pepper juice</title>
-      <link>/posts/lacto-pepper-juice/</link>
+      <link>https://blog.skouf.com/posts/lacto-pepper-juice/</link>
       <pubDate>Wed, 24 Feb 2021 22:30:51 +0000</pubDate>
       
-      <guid>/posts/lacto-pepper-juice/</guid>
+      <guid>https://blog.skouf.com/posts/lacto-pepper-juice/</guid>
       <description>How to make a tangy, delicious, smoky, umami rich ferment from red peppers</description>
     </item>
     
     <item>
       <title>Fig leaf syrup and fig leaf lemonade</title>
-      <link>/posts/fig-leaf-syrup/</link>
+      <link>https://blog.skouf.com/posts/fig-leaf-syrup/</link>
       <pubDate>Sun, 14 Feb 2021 01:00:56 +0000</pubDate>
       
-      <guid>/posts/fig-leaf-syrup/</guid>
+      <guid>https://blog.skouf.com/posts/fig-leaf-syrup/</guid>
       <description>A unique and versatile syrup, and a refreshing, summery lemonade</description>
     </item>
     
     <item>
       <title>IaC in the home - two years on</title>
-      <link>/posts/iac-in-the-home-two-years-on/</link>
+      <link>https://blog.skouf.com/posts/iac-in-the-home-two-years-on/</link>
       <pubDate>Sat, 11 Apr 2020 02:25:23 +0000</pubDate>
       
-      <guid>/posts/iac-in-the-home-two-years-on/</guid>
+      <guid>https://blog.skouf.com/posts/iac-in-the-home-two-years-on/</guid>
       <description>After two years of running a home Kubernetes setup, I have more thoughts and lessons about how to run a home cluster.</description>
     </item>
     
     <item>
       <title>Blog migration</title>
-      <link>/posts/blog-migration/blog-migration/</link>
+      <link>https://blog.skouf.com/posts/blog-migration/blog-migration/</link>
       <pubDate>Wed, 08 Apr 2020 02:30:18 +0000</pubDate>
       
-      <guid>/posts/blog-migration/blog-migration/</guid>
+      <guid>https://blog.skouf.com/posts/blog-migration/blog-migration/</guid>
       <description>It&amp;rsquo;s finally time to take my blog off of Medium and host it myself.</description>
     </item>
     
     <item>
       <title>Istio TLS policies - ugly bits and undocumented bits</title>
-      <link>/posts/istio-tls-policies/</link>
+      <link>https://blog.skouf.com/posts/istio-tls-policies/</link>
       <pubDate>Wed, 12 Jun 2019 00:43:25 +0000</pubDate>
       
-      <guid>/posts/istio-tls-policies/</guid>
+      <guid>https://blog.skouf.com/posts/istio-tls-policies/</guid>
       <description>One of the selling points of deploying Istio in your Kubernetes cluster is that it provides mechanisms to enforce authentication between pods communicating with other services within the cluster. The documentation of these leaves a lot to be desired, as we discovered when we first started playing with these features while gearing up to roll out Istio more widely.</description>
     </item>
     
     <item>
       <title>Infrastructure as code in the home - one year on</title>
-      <link>/posts/iac-in-the-home-one-year-on/</link>
+      <link>https://blog.skouf.com/posts/iac-in-the-home-one-year-on/</link>
       <pubDate>Wed, 09 Jan 2019 00:43:25 +0000</pubDate>
       
-      <guid>/posts/iac-in-the-home-one-year-on/</guid>
+      <guid>https://blog.skouf.com/posts/iac-in-the-home-one-year-on/</guid>
       <description>One year on, I revisit my home infrastructure as code setup. I explore what worked, what didn&amp;rsquo;t and what has changed over the last year.</description>
     </item>
     
     <item>
       <title>Infrastructure as code in the home</title>
-      <link>/posts/iac-in-the-home/</link>
+      <link>https://blog.skouf.com/posts/iac-in-the-home/</link>
       <pubDate>Wed, 25 Apr 2018 23:12:23 +1100</pubDate>
       
-      <guid>/posts/iac-in-the-home/</guid>
+      <guid>https://blog.skouf.com/posts/iac-in-the-home/</guid>
       <description>&lt;p&gt;Infrastructure as Code (herein IaC) is ubiquitous when managing large infrastructure deployments.
 But when we don’t have hundreds of machines to manage, is IaC still useful?&lt;/p&gt;</description>
     </item>
     
     <item>
       <title>Log4net rolling file appender with multiple projects</title>
-      <link>/posts/log-4-net-rolling-file-appender/</link>
+      <link>https://blog.skouf.com/posts/log-4-net-rolling-file-appender/</link>
       <pubDate>Mon, 03 Apr 2017 23:12:23 +1100</pubDate>
       
-      <guid>/posts/log-4-net-rolling-file-appender/</guid>
+      <guid>https://blog.skouf.com/posts/log-4-net-rolling-file-appender/</guid>
       <description>&lt;p&gt;The purpose of this article is to document a minor frustration I ran into at work a few weeks ago, in the hopes that somebody else with the same issue will stumble across it.
 If I can save another poor soul some time, then it will be well worth writing this.&lt;/p&gt;</description>
     </item>
     
     <item>
       <title>Monterey K104 restoration</title>
-      <link>/posts/monterey-k104-restoration/</link>
+      <link>https://blog.skouf.com/posts/monterey-k104-restoration/</link>
       <pubDate>Sat, 10 Sep 2016 23:12:23 +1100</pubDate>
       
-      <guid>/posts/monterey-k104-restoration/</guid>
+      <guid>https://blog.skouf.com/posts/monterey-k104-restoration/</guid>
       <description>A detailed step-by-step of restoring a keyboard older than I am. Not for the faint-of-keyboard.</description>
     </item>
     

--- a/docs/posts/istio-tls-policies/index.html
+++ b/docs/posts/istio-tls-policies/index.html
@@ -12,9 +12,9 @@
   <meta name="keywords" content="">
   <meta property="og:site_name" content="blog.skouf.com">
   <meta property="og:title" content="Istio TLS policies - ugly bits and undocumented bits">
-  <meta property="og:url" content="/posts/istio-tls-policies/">
+  <meta property="og:url" content="https://blog.skouf.com/posts/istio-tls-policies/">
   
-  <meta property="og:image" content="sailboat.jpg">
+  <meta property="og:image" content="https://blog.skouf.com/sailboat.jpg">
   
   
   <meta property="og:description" content="One of the selling points of deploying Istio in your Kubernetes cluster is that it provides mechanisms to enforce authentication between pods communicating with other services within the cluster. The documentation of these leaves a lot to be desired, as we discovered when we first started playing with these features while gearing up to roll out Istio more widely.">
@@ -23,12 +23,12 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:creator" content="@niksko">
   <meta name="twitter:title" content="Istio TLS policies - ugly bits and undocumented bits">
-  <meta name="twitter:url" content="/posts/istio-tls-policies/">
+  <meta name="twitter:url" content="https://blog.skouf.com/posts/istio-tls-policies/">
   
   <meta name="twitter:description" content="One of the selling points of deploying Istio in your Kubernetes cluster is that it provides mechanisms to enforce authentication between pods communicating with other services within the cluster. The documentation of these leaves a lot to be desired, as we discovered when we first started playing with these features while gearing up to roll out Istio more widely.">
   
   
-  <meta name="twitter:image:src" content="sailboat.jpg">
+  <meta name="twitter:image:src" content="https://blog.skouf.com/sailboat.jpg">
   
   <link rel="shortcut icon" href="/image/theme/favicon.ico">
   <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
@@ -36,7 +36,7 @@
   <link rel="stylesheet" href="https://unpkg.com/purecss@1.0.0/build/grids-responsive-min.css">
   <link rel="stylesheet" href="/css/style.css">
   <link rel="stylesheet" href="/css/syntax.css">
-  <link rel="alternate" href="index.xml" type="application/rss+xml" title="blog.skouf.com">
+  <link rel="alternate" href="https://blog.skouf.com/index.xml" type="application/rss+xml" title="blog.skouf.com">
 </head>
 
 <body>
@@ -377,7 +377,7 @@ As I dive deeper into setting up Istio in a production environment, I hope to pr
   <ol class="pure-g">
     
       <li class="pure-u-1 pure-u-md-1-2 post-nav-prev">
-        <a href="/posts/blog-migration/blog-migration/">
+        <a href="https://blog.skouf.com/posts/blog-migration/blog-migration/">
               <span class="post-nav-label">Next<span>
               <span class="post-nav-title">
                 Blog migration
@@ -387,7 +387,7 @@ As I dive deeper into setting up Istio in a production environment, I hope to pr
     
     
       <li class="pure-u-1 pure-u-md-1-2 post-nav-next">
-        <a href="/posts/iac-in-the-home-one-year-on/">
+        <a href="https://blog.skouf.com/posts/iac-in-the-home-one-year-on/">
           <span class="post-nav-label">Previous</span>
           <span class="post-nav-title">
                 Infrastructure as code in the home - one year on

--- a/docs/posts/lacto-pepper-juice/index.html
+++ b/docs/posts/lacto-pepper-juice/index.html
@@ -12,9 +12,9 @@
   <meta name="keywords" content="">
   <meta property="og:site_name" content="blog.skouf.com">
   <meta property="og:title" content="Lacto-fermented red pepper juice">
-  <meta property="og:url" content="/posts/lacto-pepper-juice/">
+  <meta property="og:url" content="https://blog.skouf.com/posts/lacto-pepper-juice/">
   
-  <meta property="og:image" content="charred-peppers.jpg">
+  <meta property="og:image" content="https://blog.skouf.com/charred-peppers.jpg">
   
   
   <meta property="og:description" content="How to make a tangy, delicious, smoky, umami rich ferment from red peppers">
@@ -23,12 +23,12 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:creator" content="@niksko">
   <meta name="twitter:title" content="Lacto-fermented red pepper juice">
-  <meta name="twitter:url" content="/posts/lacto-pepper-juice/">
+  <meta name="twitter:url" content="https://blog.skouf.com/posts/lacto-pepper-juice/">
   
   <meta name="twitter:description" content="How to make a tangy, delicious, smoky, umami rich ferment from red peppers">
   
   
-  <meta name="twitter:image:src" content="charred-peppers.jpg">
+  <meta name="twitter:image:src" content="https://blog.skouf.com/charred-peppers.jpg">
   
   <link rel="shortcut icon" href="/image/theme/favicon.ico">
   <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
@@ -36,7 +36,7 @@
   <link rel="stylesheet" href="https://unpkg.com/purecss@1.0.0/build/grids-responsive-min.css">
   <link rel="stylesheet" href="/css/style.css">
   <link rel="stylesheet" href="/css/syntax.css">
-  <link rel="alternate" href="index.xml" type="application/rss+xml" title="blog.skouf.com">
+  <link rel="alternate" href="https://blog.skouf.com/index.xml" type="application/rss+xml" title="blog.skouf.com">
 </head>
 
 <body>
@@ -671,7 +671,7 @@ out of place on a rice bowl with mostly Japanese flavors.</p>
   <ol class="pure-g">
     
       <li class="pure-u-1 pure-u-md-1-2 post-nav-prev">
-        <a href="/posts/experiments-in-mushroom-garrum/">
+        <a href="https://blog.skouf.com/posts/experiments-in-mushroom-garrum/">
               <span class="post-nav-label">Next<span>
               <span class="post-nav-title">
                 Experiments in mushroom garrum
@@ -681,7 +681,7 @@ out of place on a rice bowl with mostly Japanese flavors.</p>
     
     
       <li class="pure-u-1 pure-u-md-1-2 post-nav-next">
-        <a href="/posts/fig-leaf-syrup/">
+        <a href="https://blog.skouf.com/posts/fig-leaf-syrup/">
           <span class="post-nav-label">Previous</span>
           <span class="post-nav-title">
                 Fig leaf syrup and fig leaf lemonade

--- a/docs/posts/log-4-net-rolling-file-appender/index.html
+++ b/docs/posts/log-4-net-rolling-file-appender/index.html
@@ -13,9 +13,9 @@ If I can save another poor soul some time, then it will be well worth writing th
   <meta name="keywords" content="">
   <meta property="og:site_name" content="blog.skouf.com">
   <meta property="og:title" content="Log4net rolling file appender with multiple projects">
-  <meta property="og:url" content="/posts/log-4-net-rolling-file-appender/">
+  <meta property="og:url" content="https://blog.skouf.com/posts/log-4-net-rolling-file-appender/">
   
-  <meta property="og:image" content="log4net-logo.jpg">
+  <meta property="og:image" content="https://blog.skouf.com/log4net-logo.jpg">
   
   
   <meta property="og:description" content="The purpose of this article is to document a minor frustration I ran into at work a few weeks ago, in the hopes that somebody else with the same issue will stumble across it.
@@ -25,13 +25,13 @@ If I can save another poor soul some time, then it will be well worth writing th
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:creator" content="@niksko">
   <meta name="twitter:title" content="Log4net rolling file appender with multiple projects">
-  <meta name="twitter:url" content="/posts/log-4-net-rolling-file-appender/">
+  <meta name="twitter:url" content="https://blog.skouf.com/posts/log-4-net-rolling-file-appender/">
   
   <meta name="twitter:description" content="The purpose of this article is to document a minor frustration I ran into at work a few weeks ago, in the hopes that somebody else with the same issue will stumble across it.
 If I can save another poor soul some time, then it will be well worth writing this.">
   
   
-  <meta name="twitter:image:src" content="log4net-logo.jpg">
+  <meta name="twitter:image:src" content="https://blog.skouf.com/log4net-logo.jpg">
   
   <link rel="shortcut icon" href="/image/theme/favicon.ico">
   <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
@@ -39,7 +39,7 @@ If I can save another poor soul some time, then it will be well worth writing th
   <link rel="stylesheet" href="https://unpkg.com/purecss@1.0.0/build/grids-responsive-min.css">
   <link rel="stylesheet" href="/css/style.css">
   <link rel="stylesheet" href="/css/syntax.css">
-  <link rel="alternate" href="index.xml" type="application/rss+xml" title="blog.skouf.com">
+  <link rel="alternate" href="https://blog.skouf.com/index.xml" type="application/rss+xml" title="blog.skouf.com">
 </head>
 
 <body>
@@ -94,7 +94,7 @@ The solution is to force log4net to only lock the specific file that will be use
   <ol class="pure-g">
     
       <li class="pure-u-1 pure-u-md-1-2 post-nav-prev">
-        <a href="/posts/iac-in-the-home/">
+        <a href="https://blog.skouf.com/posts/iac-in-the-home/">
               <span class="post-nav-label">Next<span>
               <span class="post-nav-title">
                 Infrastructure as code in the home
@@ -104,7 +104,7 @@ The solution is to force log4net to only lock the specific file that will be use
     
     
       <li class="pure-u-1 pure-u-md-1-2 post-nav-next">
-        <a href="/posts/monterey-k104-restoration/">
+        <a href="https://blog.skouf.com/posts/monterey-k104-restoration/">
           <span class="post-nav-label">Previous</span>
           <span class="post-nav-title">
                 Monterey K104 restoration

--- a/docs/posts/monterey-k104-restoration/index.html
+++ b/docs/posts/monterey-k104-restoration/index.html
@@ -12,9 +12,9 @@
   <meta name="keywords" content="">
   <meta property="og:site_name" content="blog.skouf.com">
   <meta property="og:title" content="Monterey K104 restoration">
-  <meta property="og:url" content="/posts/monterey-k104-restoration/">
+  <meta property="og:url" content="https://blog.skouf.com/posts/monterey-k104-restoration/">
   
-  <meta property="og:image" content="first-image.jpg">
+  <meta property="og:image" content="https://blog.skouf.com/first-image.jpg">
   
   
   <meta property="og:description" content="A detailed step-by-step of restoring a keyboard older than I am. Not for the faint-of-keyboard.">
@@ -23,12 +23,12 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:creator" content="@niksko">
   <meta name="twitter:title" content="Monterey K104 restoration">
-  <meta name="twitter:url" content="/posts/monterey-k104-restoration/">
+  <meta name="twitter:url" content="https://blog.skouf.com/posts/monterey-k104-restoration/">
   
   <meta name="twitter:description" content="A detailed step-by-step of restoring a keyboard older than I am. Not for the faint-of-keyboard.">
   
   
-  <meta name="twitter:image:src" content="first-image.jpg">
+  <meta name="twitter:image:src" content="https://blog.skouf.com/first-image.jpg">
   
   <link rel="shortcut icon" href="/image/theme/favicon.ico">
   <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
@@ -36,7 +36,7 @@
   <link rel="stylesheet" href="https://unpkg.com/purecss@1.0.0/build/grids-responsive-min.css">
   <link rel="stylesheet" href="/css/style.css">
   <link rel="stylesheet" href="/css/syntax.css">
-  <link rel="alternate" href="index.xml" type="application/rss+xml" title="blog.skouf.com">
+  <link rel="alternate" href="https://blog.skouf.com/index.xml" type="application/rss+xml" title="blog.skouf.com">
 </head>
 
 <body>
@@ -1116,7 +1116,7 @@ It’s really wonderful to type on, and I really hope there are no complaints fr
   <ol class="pure-g">
     
       <li class="pure-u-1 pure-u-md-1-2 post-nav-prev">
-        <a href="/posts/log-4-net-rolling-file-appender/">
+        <a href="https://blog.skouf.com/posts/log-4-net-rolling-file-appender/">
               <span class="post-nav-label">Next<span>
               <span class="post-nav-title">
                 Log4net rolling file appender with multiple projects

--- a/docs/posts/page/1/index.html
+++ b/docs/posts/page/1/index.html
@@ -1,1 +1,1 @@
-<!DOCTYPE html><html><head><title>/posts/</title><link rel="canonical" href="/posts/"/><meta name="robots" content="noindex"><meta charset="utf-8" /><meta http-equiv="refresh" content="0; url=/posts/" /></head></html>
+<!DOCTYPE html><html><head><title>https://blog.skouf.com/posts/</title><link rel="canonical" href="https://blog.skouf.com/posts/"/><meta name="robots" content="noindex"><meta charset="utf-8" /><meta http-equiv="refresh" content="0; url=https://blog.skouf.com/posts/" /></head></html>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -3,67 +3,67 @@
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   
   <url>
-    <loc>/</loc>
+    <loc>https://blog.skouf.com/</loc>
     <lastmod>2021-02-27T12:00:14+00:00</lastmod>
   </url>
   
   <url>
-    <loc>/posts/experiments-in-mushroom-garrum/</loc>
+    <loc>https://blog.skouf.com/posts/experiments-in-mushroom-garrum/</loc>
     <lastmod>2021-02-27T12:00:14+00:00</lastmod>
   </url>
   
   <url>
-    <loc>/posts/</loc>
+    <loc>https://blog.skouf.com/posts/</loc>
     <lastmod>2021-02-27T12:00:14+00:00</lastmod>
   </url>
   
   <url>
-    <loc>/posts/lacto-pepper-juice/</loc>
+    <loc>https://blog.skouf.com/posts/lacto-pepper-juice/</loc>
     <lastmod>2021-02-24T22:30:51+00:00</lastmod>
   </url>
   
   <url>
-    <loc>/posts/fig-leaf-syrup/</loc>
+    <loc>https://blog.skouf.com/posts/fig-leaf-syrup/</loc>
     <lastmod>2021-02-14T01:00:56+00:00</lastmod>
   </url>
   
   <url>
-    <loc>/posts/iac-in-the-home-two-years-on/</loc>
+    <loc>https://blog.skouf.com/posts/iac-in-the-home-two-years-on/</loc>
     <lastmod>2020-04-11T02:25:23+00:00</lastmod>
   </url>
   
   <url>
-    <loc>/posts/blog-migration/blog-migration/</loc>
+    <loc>https://blog.skouf.com/posts/blog-migration/blog-migration/</loc>
     <lastmod>2020-04-08T02:30:18+00:00</lastmod>
   </url>
   
   <url>
-    <loc>/posts/istio-tls-policies/</loc>
+    <loc>https://blog.skouf.com/posts/istio-tls-policies/</loc>
     <lastmod>2019-06-12T00:43:25+00:00</lastmod>
   </url>
   
   <url>
-    <loc>/posts/iac-in-the-home-one-year-on/</loc>
+    <loc>https://blog.skouf.com/posts/iac-in-the-home-one-year-on/</loc>
     <lastmod>2019-01-09T00:43:25+00:00</lastmod>
   </url>
   
   <url>
-    <loc>/posts/iac-in-the-home/</loc>
+    <loc>https://blog.skouf.com/posts/iac-in-the-home/</loc>
     <lastmod>2018-04-25T23:12:23+11:00</lastmod>
   </url>
   
   <url>
-    <loc>/posts/log-4-net-rolling-file-appender/</loc>
+    <loc>https://blog.skouf.com/posts/log-4-net-rolling-file-appender/</loc>
     <lastmod>2017-04-03T23:12:23+11:00</lastmod>
   </url>
   
   <url>
-    <loc>/posts/monterey-k104-restoration/</loc>
+    <loc>https://blog.skouf.com/posts/monterey-k104-restoration/</loc>
     <lastmod>2016-09-10T23:12:23+11:00</lastmod>
   </url>
   
   <url>
-    <loc>/tags/</loc>
+    <loc>https://blog.skouf.com/tags/</loc>
   </url>
   
 </urlset>

--- a/docs/tags/index.html
+++ b/docs/tags/index.html
@@ -12,9 +12,9 @@
   <meta name="keywords" content="">
   <meta property="og:site_name" content="blog.skouf.com">
   <meta property="og:title" content="Tags">
-  <meta property="og:url" content="/tags/">
+  <meta property="og:url" content="https://blog.skouf.com/tags/">
   
-  <meta property="og:image" content="image/theme/og.png">
+  <meta property="og:image" content="https://blog.skouf.com/image/theme/og.png">
   
   
   <meta property="og:description" content="">
@@ -23,12 +23,12 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:creator" content="@niksko">
   <meta name="twitter:title" content="Tags">
-  <meta name="twitter:url" content="/tags/">
+  <meta name="twitter:url" content="https://blog.skouf.com/tags/">
   
   <meta name="twitter:description" content="">
   
   
-  <meta name="twitter:image:src" content="image/theme/og.png">
+  <meta name="twitter:image:src" content="https://blog.skouf.com/image/theme/og.png">
   
   <link rel="shortcut icon" href="/image/theme/favicon.ico">
   <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
@@ -36,7 +36,7 @@
   <link rel="stylesheet" href="https://unpkg.com/purecss@1.0.0/build/grids-responsive-min.css">
   <link rel="stylesheet" href="/css/style.css">
   <link rel="stylesheet" href="/css/syntax.css">
-  <link rel="alternate" href="index.xml" type="application/rss+xml" title="blog.skouf.com">
+  <link rel="alternate" href="https://blog.skouf.com/index.xml" type="application/rss+xml" title="blog.skouf.com">
 </head>
 
 <body>

--- a/docs/tags/index.xml
+++ b/docs/tags/index.xml
@@ -2,9 +2,9 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>Tags on blog.skouf.com</title>
-    <link>/tags/</link>
+    <link>https://blog.skouf.com/tags/</link>
     <description>Recent content in Tags on blog.skouf.com</description>
     <generator>Hugo -- gohugo.io</generator>
-    <language>en-us</language><atom:link href="/tags/index.xml" rel="self" type="application/rss+xml" />
+    <language>en-us</language><atom:link href="https://blog.skouf.com/tags/index.xml" rel="self" type="application/rss+xml" />
   </channel>
 </rss>

--- a/docs/tags/page/1/index.html
+++ b/docs/tags/page/1/index.html
@@ -1,1 +1,1 @@
-<!DOCTYPE html><html><head><title>/tags/</title><link rel="canonical" href="/tags/"/><meta name="robots" content="noindex"><meta charset="utf-8" /><meta http-equiv="refresh" content="0; url=/tags/" /></head></html>
+<!DOCTYPE html><html><head><title>https://blog.skouf.com/tags/</title><link rel="canonical" href="https://blog.skouf.com/tags/"/><meta name="robots" content="noindex"><meta charset="utf-8" /><meta http-equiv="refresh" content="0; url=https://blog.skouf.com/tags/" /></head></html>


### PR DESCRIPTION
Hey Nik! This just adds a baseURL to your site's config so RSS readers can link to the full article on your blog correctly.

Previously links would point to `/posts/fig-leaf-syrup/` - corresponding to the local filesystem, and subsequently failing to resolve.

I don't believe this should break anything existing in your current setup, so long as you're not serving that `/docs` directory from multiple hosts. In that case you can run builds for each host with a different baseURL and output directory.

```sh
hugo --baseURL "https://blog.skouf.com/" --destination "/var/www/blog.skouf.com/"
```

Cheers, Nicholas